### PR TITLE
Align todo module with admin-based schema

### DIFF
--- a/db.php
+++ b/db.php
@@ -20,4 +20,12 @@ try {
 } catch (\PDOException $e) {
     die('Verbindungsfehler: ' . $e->getMessage());
 }
+
+// Zusätzliches MySQLi-Objekt für ältere Skripte
+$conn = new mysqli($host, $user, $pass, $db);
+if ($conn->connect_error) {
+    die('Verbindungsfehler: ' . $conn->connect_error);
+}
+$conn->set_charset($charset);
+
 ?>


### PR DESCRIPTION
## Summary
- Switch todo module to `admin_session` and role checks like `rechnungen.php`
- Rename To-Do tables and columns to use `admin_*` fields, matching `todo1.sql`
- Add MySQLi connection in `db.php` for legacy code support

## Testing
- `php -l db.php`
- `php -l todo.php`


------
https://chatgpt.com/codex/tasks/task_e_68be77aab76083318b0c8ea7e0eb9f50